### PR TITLE
feat: add match result analysis with REST endpoints

### DIFF
--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/controller/MatchController.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/controller/MatchController.java
@@ -1,0 +1,29 @@
+package com.predictionTooling.predictionTooling.controller;
+
+import com.predictionTooling.predictionTooling.service.MatchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+    @RestController
+    @RequestMapping("/matches")
+    public class MatchController {
+
+        private final MatchService matchService;
+
+        @Autowired
+        public MatchController(MatchService matchService) {
+            this.matchService = matchService;
+        }
+
+        // Example: /matches/didWin?team=Arsenal
+        @GetMapping("/didWin")
+        public String didWin(@RequestParam String team) {
+            return matchService.didTeamWin(team);
+        }
+
+        // Example: /matches/didBeat?teamA=Arsenal&teamB=Chelsea
+        @GetMapping("/didBeat")
+        public String didBeat(@RequestParam String teamA, @RequestParam String teamB) {
+            return matchService.didTeamBeat(teamA, teamB);
+        }
+    }

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/Market.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/Market.java
@@ -1,4 +1,4 @@
-package com.predictionTooling.predictionTooling.dto;
+package com.predictionTooling.predictionTooling.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/MarketsResponse.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/MarketsResponse.java
@@ -1,4 +1,4 @@
-package com.predictionTooling.predictionTooling.dto;
+package com.predictionTooling.predictionTooling.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/MatchResult.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/MatchResult.java
@@ -1,0 +1,102 @@
+package com.predictionTooling.predictionTooling.model;
+
+import java.util.Objects;
+
+public class MatchResult {
+
+    private String team1;
+    private String team2;
+    private int score1;
+    private int score2;
+
+    // Constructor
+    public MatchResult(String team1, String team2, int score1, int score2) {
+        this.team1 = team1;
+        this.team2 = team2;
+        this.score1 = score1;
+        this.score2 = score2;
+    }
+
+    // Default constructor (needed if you use frameworks that require it)
+    public MatchResult() {
+    }
+
+    // Getters and setters
+    public String getTeam1() {
+        return team1;
+    }
+
+    public void setTeam1(String team1) {
+        this.team1 = team1;
+    }
+
+    public String getTeam2() {
+        return team2;
+    }
+
+    public void setTeam2(String team2) {
+        this.team2 = team2;
+    }
+
+    public int getScore1() {
+        return score1;
+    }
+
+    public void setScore1(int score1) {
+        this.score1 = score1;
+    }
+
+    public int getScore2() {
+        return score2;
+    }
+
+    public void setScore2(int score2) {
+        this.score2 = score2;
+    }
+
+    // Business logic methods
+
+    // Returns the winner team name or "Draw"
+    public String getWinner() {
+        if (score1 > score2) {
+            return team1;
+        } else if (score2 > score1) {
+            return team2;
+        } else {
+            return "Draw";
+        }
+    }
+
+    // Checks if this match involves the given team (case insensitive)
+    public boolean involvesTeam(String team) {
+        return team1.equalsIgnoreCase(team) || team2.equalsIgnoreCase(team);
+    }
+
+    // Checks if this match is between the two given teams (in any order)
+    public boolean isMatchBetween(String teamA, String teamB) {
+        return (team1.equalsIgnoreCase(teamA) && team2.equalsIgnoreCase(teamB)) ||
+                (team1.equalsIgnoreCase(teamB) && team2.equalsIgnoreCase(teamA));
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s %d - %d %s", team1, score1, score2, team2);
+    }
+
+    // Override equals and hashCode for good practice (optional, but recommended)
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MatchResult)) return false;
+        MatchResult that = (MatchResult) o;
+        return score1 == that.score1 &&
+                score2 == that.score2 &&
+                team1.equalsIgnoreCase(that.team1) &&
+                team2.equalsIgnoreCase(that.team2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(team1.toLowerCase(), team2.toLowerCase(), score1, score2);
+    }
+}

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/Series.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/Series.java
@@ -1,4 +1,4 @@
-package com.predictionTooling.predictionTooling.dto;
+package com.predictionTooling.predictionTooling.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/SeriesListResponse.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/model/SeriesListResponse.java
@@ -1,4 +1,4 @@
-package com.predictionTooling.predictionTooling.dto;
+package com.predictionTooling.predictionTooling.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/provider/KalshiProvider.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/provider/KalshiProvider.java
@@ -2,7 +2,7 @@ package com.predictionTooling.predictionTooling.provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.predictionTooling.predictionTooling.dto.*;
+import com.predictionTooling.predictionTooling.model.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;

--- a/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/service/MatchService.java
+++ b/predictionTooling/src/main/java/com/predictionTooling/predictionTooling/service/MatchService.java
@@ -1,0 +1,49 @@
+package com.predictionTooling.predictionTooling.service;
+
+
+import com.predictionTooling.predictionTooling.model.MatchResult;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MatchService {
+
+    private final List<MatchResult> matches = List.of(
+            new MatchResult("Arsenal", "Chelsea", 2, 1),
+            new MatchResult("Barcelona", "Real Madrid", 0, 2),
+            new MatchResult("QWER", "ASDF", 3, 3)
+    );
+
+    public String didTeamWin(String team) {
+        for (MatchResult match : matches) {
+            if (match.involvesTeam(team)) {
+                String winner = match.getWinner();
+                if (winner.equalsIgnoreCase(team)) {
+                    return "Yes, " + team + " won. Match: " + match;
+                } else if (winner.equals("Draw")) {
+                    return "No, it was a draw. Match: " + match;
+                } else {
+                    return "No, " + winner + " won. Match: " + match;
+                }
+            }
+        }
+        return "No match found for " + team;
+    }
+
+    public String didTeamBeat(String teamA, String teamB) {
+        for (MatchResult match : matches) {
+            if (match.isMatchBetween(teamA, teamB)) {
+                String winner = match.getWinner();
+                if (winner.equalsIgnoreCase(teamA)) {
+                    return "Yes, " + teamA + " beat " + teamB + ". Match: " + match;
+                } else if (winner.equalsIgnoreCase(teamB)) {
+                    return "No, " + teamB + " won. Match: " + match;
+                } else {
+                    return "No, it was a draw between " + teamA + " and " + teamB + ". Match: " + match;
+                }
+            }
+        }
+        return "No match found between " + teamA + " and " + teamB;
+    }
+}


### PR DESCRIPTION
feat: add match result analysis with REST endpoints

- Added MatchResult model to represent football match data
- Implemented MatchService with logic to determine match outcomes:
    - didTeamWin(team)
    - didTeamBeat(teamA, teamB)
- Created MatchController with two GET endpoints:
    - /matches/didWin?team=...
    - /matches/didBeat?teamA=...&teamB=...
- Sample match data currently hardcoded in service
- Removed redundant MatchAnalyzer class from util package
- Organized code into model, service, and controller layers
